### PR TITLE
Fix rescheduling of timers + enable logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.vscode/**
 /config.json
 /database.db
+/bot.log

--- a/study_bot/bot.py
+++ b/study_bot/bot.py
@@ -1,8 +1,16 @@
 from discord.ext.commands import Bot
 import json
+import logging
 
 from . import cogs
 from .data import Repository
+
+#Setup logging
+log = logging.getLogger('botlog')
+log.setLevel(logging.INFO)
+handler = logging.FileHandler(filename='bot.log', encoding='utf-8', mode='a')
+handler.setFormatter(logging.Formatter('%(asctime)s [%(levelname)s] %(message)s'))
+log.addHandler(handler)
 
 class StudyBot(Bot):
 
@@ -12,15 +20,17 @@ class StudyBot(Bot):
         cogs.add_all(self)
 
     async def on_ready(self):
-        print('Bot loaded')
+        log.info('Bot: on_ready')
 
     async def close(self):
         await super().close()
         self.repository.close()
-        print('Bot exited')
+        log.info('Bot exited')
 
 def main():
     """Entry point of the bot"""
+
+    log.info('******Starting up bot******')
     
     with open('config.json') as fp:
         config = json.loads(fp.read())

--- a/study_bot/cogs/__init__.py
+++ b/study_bot/cogs/__init__.py
@@ -1,6 +1,7 @@
 from .timer import TimerCog
 from .misc import Misc
 from .donotdisturb import DndCog
+from .admin import AdminCog
 
 def add_all(bot):
     """Add all available cogs to the bot"""
@@ -8,6 +9,7 @@ def add_all(bot):
     bot.add_cog(TimerCog())
     bot.add_cog(DndCog())
     bot.add_cog(Misc())
+    bot.add_cog(AdminCog())
 
 all = [
     'add_all',

--- a/study_bot/cogs/__init__.py
+++ b/study_bot/cogs/__init__.py
@@ -1,10 +1,12 @@
 from .timer import TimerCog
 from .misc import Misc
+from .donotdisturb import DndCog
 
 def add_all(bot):
     """Add all available cogs to the bot"""
     
     bot.add_cog(TimerCog())
+    bot.add_cog(DndCog())
     bot.add_cog(Misc())
 
 all = [

--- a/study_bot/cogs/admin.py
+++ b/study_bot/cogs/admin.py
@@ -1,0 +1,12 @@
+from discord.ext.commands import Cog, command, Context
+from discord import File
+
+class AdminCog(Cog):
+    """Admin commands meant to be used by admin of the bot"""
+    
+    @command(name='dumplog', hidden=True)
+    async def dump_log(self, ctx: Context):
+        if await ctx.bot.is_owner(ctx.author):
+            await ctx.send(files=[File('bot.log')])
+
+        else: await ctx.send('You are not authorized to use this command')

--- a/study_bot/cogs/donotdisturb.py
+++ b/study_bot/cogs/donotdisturb.py
@@ -1,0 +1,66 @@
+from discord.ext import commands
+from discord.ext.commands import Cog, command, Context, MissingPermissions
+from discord.utils import get
+
+class DndCog(Cog):
+
+    ROLE_NAME = "Focus mode"
+
+    @command(name='focusmode')
+    async def dnd(self, ctx: Context, *args):
+        """Turn focusmode on/off
+        Example:
+        focusmode on
+        focusmode off
+        """
+
+        bot_perms = ctx.guild.me.permissions_in(ctx.channel)
+        if not bot_perms.manage_roles:
+            await ctx.send("Please give the 'Manage roles' permission to use this command")
+
+        if len(args) != 1 or not args[0] in ['on', 'off']:
+            await ctx.send('Usage: `focusmode [on | off]`')
+            return
+
+        role = get(ctx.guild.roles, name=DndCog.ROLE_NAME)
+        if role == None:
+            await ctx.send(f'{DndCog.ROLE_NAME} role is not set up. An admin must run `setupdnd` command to set it up')
+            return
+
+        if args[0] == 'on':
+            await ctx.author.add_roles(role)
+            await ctx.send('Your focus mode is now turned on!')
+        else:
+            await ctx.author.remove_roles(role)
+            await ctx.send('Your focus mode is now turned off!')
+
+    @command(name='setupdnd')
+    @commands.has_permissions(manage_roles=True)
+    async def setup_channels(self, ctx: Context, *channels):
+        """Setup focus-mode
+        Creates Focus mode role and forbids the role to read messages from given channels"""
+
+        bot_perms = ctx.guild.me.permissions_in(ctx.channel)
+        if not bot_perms.manage_roles:
+            await ctx.send("Please give the 'Manage roles' permission to use this command")
+        
+        role = get(ctx.guild.roles, name=DndCog.ROLE_NAME)
+        if role != None:
+            await role.delete()
+
+        role = await ctx.guild.create_role(name=DndCog.ROLE_NAME)
+
+        channels = [ get(ctx.guild.channels, mention=it) for it in channels ]
+
+        if None in channels:
+            await ctx.send('One or more channels are invalid')
+
+        for channel in channels:
+            await channel.set_permissions(role, read_messages=False)
+
+        await ctx.send(f'{DndCog.ROLE_NAME} role set up complete!')
+
+    @setup_channels.error
+    async def setup_channels_error(self, ctx: Context, e: Exception):
+        if isinstance(e, MissingPermissions):
+            await ctx.send(str(e))

--- a/study_bot/cogs/timer.py
+++ b/study_bot/cogs/timer.py
@@ -32,7 +32,9 @@ class TimerCog(Cog):
     @Cog.listener()
     async def on_connect(self):
         print('on_connect')
-        if not self.db_scheduled: await self.schedule_timers_from_db(self.bot)
+        if not self.db_scheduled:
+            self.db_scheduled = True
+            await self.schedule_timers_from_db(self.bot)
      
     @command('timer')
     async def timer(self, ctx: Context, *args):
@@ -184,6 +186,11 @@ class TimerCog(Cog):
                 print("KeyError while cleaning up timer id=", timer.id, file=sys.stderr)
 
             self.dao.finish_timer(timer)
+
+        #Check if the timer with the same id is already present in the dict
+        if timer.id in self.timer_tasks.keys():
+            print('[ WARN ]', 'Tried to re-schedule timer. id=', timer.id, file=sys.stderr)
+            return
 
         self.timer_tasks[timer.id] = asyncio.create_task(timer_task())
 

--- a/study_bot/cogs/timer.py
+++ b/study_bot/cogs/timer.py
@@ -89,7 +89,7 @@ class TimerCog(Cog):
         await self.schedule_timer(timer, ctx.bot)
         
         await ctx.send(f"There ya go. I'll ping you in {hours}h {minutes}m {sec}s :>")
-        log.info('Started timer id=' + timer.id)
+        log.info(f'Started timer id={timer.id}')
 
     @command(name='showtimers', aliases=['timers', 'st'])
     async def show_timers(self, ctx: Context):
@@ -166,7 +166,7 @@ class TimerCog(Cog):
         self.dao.finish_timer(timer)
 
         await ctx.send(f'Canceled timer #{timer.id}')
-        log.infot('Canceled timer id=' + timer.id)
+        log.info(f'Canceled timer id={timer.id}')
 
     async def schedule_timer(self, timer: Timer, bot: Bot):
         """Schedules a timer as a task"""
@@ -180,19 +180,19 @@ class TimerCog(Cog):
             channel = bot.get_guild(timer.guild_id).get_channel(timer.channel_id)
             await channel.send(f"<@{timer.user_id}> Yo you there? Your timer called \"{timer.reason}\" is done, don't be dead!")
 
-            log.info("Finishing timer id=" + timer.id)
+            log.info(f"Finishing timer id={timer.id}")
 
             #Cleanup
             try:
                 del self.timer_tasks[timer.id]
             except KeyError:
-                log.error("KeyError while cleaning up timer id=" + timer.id)
+                log.error(f'KeyError while cleaning up timer id={timer.id}')
 
             self.dao.finish_timer(timer)
 
         #Check if the timer with the same id is already present in the dict
         if timer.id in self.timer_tasks.keys():
-            log.warn('Tried to re-schedule timer. id=' + timer.id)
+            log.warn(f'Tried to re-schedule timer. id={timer.id}')
             return
 
         self.timer_tasks[timer.id] = asyncio.create_task(timer_task())

--- a/study_bot/data/timers_dao.py
+++ b/study_bot/data/timers_dao.py
@@ -1,7 +1,10 @@
 from typing import List, Union
 import sys
+import logging
 
 from .orm import Timer
+
+log = logging.getLogger('botlog')
 
 class TimersDao():
     def __init__(self, db_session):
@@ -21,8 +24,8 @@ class TimersDao():
         try:
             self.db_session.commit()
         except Exception as e:
+            log.error(f'Error while adding new timer to db: {e}. Rolling back')
             self.db_session.rollback()
-            print(f'Error while adding new timer to db: {e}', file=sys.stderr)
 
     def get_all_timers_for_channel(self, channel_id: int, guild_id: int) -> List[Timer]:
         """Returns a list of all active timers in the given channel of the guild"""
@@ -56,8 +59,8 @@ class TimersDao():
         try:
             self.db_session.commit()
         except Exception as e:
+            log.error(f'Error while deleting timer from db: {e}. Rolling back')
             self.db_session.rollback()
-            print(f'Error while deleting timer from db: {e}', file=sys.stderr)
     
     def get_all_timers(self) -> List[Timer]:
         """Returns the list of all timers in db"""


### PR DESCRIPTION
`on_ready` and `on_connect` events are called multiple times during the bot up-time. So these changes perform a check before scheduling timers from db.

This also enables logging the events using `logging` module to aid in detection of bugs in future.